### PR TITLE
0.0.62

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Use documentation by purpose:
 Critical distinction:
 
 - For `@sito/dashboard-app`, provider setup is `ConfigProvider -> ManagerProvider -> AuthProvider -> NotificationProvider -> DrawerMenuProvider` (`NavbarProvider` when `Navbar`/`useNavbar` is used).
+- `@sito/dashboard-app` is browser-only and **not SSR-compatible** as a package integration target.
 - `IconButton` in this package is overridden and expects `icon: IconDefinition`.
 - Upstream examples in `.sito/*` may use `@sito/dashboard` patterns (for example `IconButton` with React nodes) and must not override this file's rules.
 
@@ -860,3 +861,4 @@ Consumer projects must provide translations for these namespaces.
 24. **Prefer `IndexedDBClient.update(value)` in new code** — keep `(id, value)` only for temporary backward compatibility.
 25. **Keep documented runtime version aligned with `.nvmrc`** when writing setup instructions for this repository.
 26. **Run `npm run docs:check` after documentation edits** to validate policy markers, links, and cross-doc consistency.
+27. **Do not document or propose SSR integration for this package** — `@sito/dashboard-app` is client-side/browser-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.62] - 2026-04-09
+
+### Changed
+
+- Moved `@sito/dashboard@^0.0.75` from `peerDependencies` to `dependencies` so consumer apps do not fail with unresolved `@sito/dashboard` when only installing `@sito/dashboard-app`.
+- Tightened provider/context hook contracts:
+  - `useConfig` now uses an `undefined` default context and throws `useConfig must be used within ConfigProvider` when missing.
+  - `useManager`, `useAuthContext`, `useNotification`, and `useSupabase` now expose consistent provider-specific error messages.
+  - `useNavbar` now throws when `NavbarProvider` is missing instead of silently using no-op defaults.
+- Improved provider hook inline docs (JSDoc) with explicit return types and `@throws` semantics.
+- Updated related test expectations to match the new error messages and added explicit coverage for `useNavbar` outside `NavbarProvider`.
+
+### Fixed
+
+- Fixed `useRegisterBottomNavAction` stability when consumers pass inline action objects:
+  - registration now derives a stable comparison key to avoid unnecessary re-registration churn.
+  - hook cleanup now runs on unmount via a dedicated effect.
+- Fixed React ref render-phase mutation warning by moving `latestActionRef` synchronization to an effect instead of mutating `ref.current` during render.
+
 ## [0.0.61] - 2026-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Use documentation by target package:
 Important:
 
 - `.sito/*.md` is not the canonical integration guide for this package.
+- `@sito/dashboard-app` is **not SSR-compatible**. Treat it as browser-only (client-rendered apps).
 - For auth-enabled apps, use `ConfigProvider -> ManagerProvider -> AuthProvider -> NotificationProvider -> DrawerMenuProvider` (`NavbarProvider` when needed; `BottomNavActionProvider` optional for dynamic mobile center actions).
 - `Drawer` and `Onboarding` can run without `AuthProvider`; in that case they behave as guest-mode UI defaults.
 - `IconButton` differs by package:
@@ -34,6 +35,7 @@ pnpm add @sito/dashboard-app
 ## Requirements
 
 - Node.js `20.x` (see `.nvmrc`)
+- Browser runtime only (no SSR/server rendering for this package)
 - React `18.3.1`
 - React DOM `18.3.1`
 - `@tanstack/react-query` `5.83.0`

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -29,6 +29,11 @@ If you use Supabase backend, also install:
 npm install @supabase/supabase-js@2.100.0
 ```
 
+## Runtime scope (important)
+
+`@sito/dashboard-app` is **client-side only**. This package is not designed for SSR/server rendering pipelines.
+Use it in browser-rendered applications.
+
 ## 2. Required Providers
 
 Recommended order:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -159,6 +159,17 @@ const authStorageKeys = {
 
 - Instantiate only in browser (for example inside `useEffect` or after checking `typeof window !== "undefined"`).
 
+### 2.12 App crashes in SSR/server-render pipelines
+
+**Cause**
+
+- `@sito/dashboard-app` is a browser-focused package and relies on browser APIs (`window`, `document`, storage, portal targets).
+
+**Fix**
+
+- Do not integrate this package in SSR/server-render paths.
+- Mount usage only in client/browser-rendered app trees.
+
 ## 3. Common typing pitfalls
 
 ### 3.1 Lost type safety due to missing generics

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,12 @@ export default tseslint.config(
       ],
       "no-console": ["error", { allow: ["warn", "error"] }],
       "prefer-const": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+    },
+  },
+  {
+    files: ["**/*.test.{ts,tsx}"],
+    rules: {
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
@@ -38,6 +44,7 @@ export default tseslint.config(
       "react-hooks/rules-of-hooks": "off",
       "react-hooks/exhaustive-deps": "off",
       "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-explicit-any": "off",
     },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.61",
       "license": "MIT",
       "dependencies": {
+        "@sito/dashboard": "^0.0.75",
         "some-javascript-utils": "^0.10.10"
       },
       "devDependencies": {
@@ -57,7 +58,6 @@
         "@fortawesome/free-regular-svg-icons": "7.0.0",
         "@fortawesome/free-solid-svg-icons": "7.0.0",
         "@fortawesome/react-fontawesome": "0.2.3",
-        "@sito/dashboard": "^0.0.75",
         "@supabase/supabase-js": "2.100.0",
         "@tanstack/react-query": "5.83.0",
         "react": ">=18.2 <20",
@@ -1816,7 +1816,6 @@
       "resolved": "https://registry.npmjs.org/@sito/dashboard/-/dashboard-0.0.75.tgz",
       "integrity": "sha512-VIJgN9TEIwVgUroUqSXfdEcWC1rj5KtiYBxVSg4/EiCh0exZx+8MEGEjqSm7LQ6QKrmSdIagsou2JH7zf7/2Ug==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": ">=18.2 <20",
         "react-dom": ">=18.2 <20"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@fortawesome/free-regular-svg-icons": "7.0.0",
     "@fortawesome/free-solid-svg-icons": "7.0.0",
     "@fortawesome/react-fontawesome": "0.2.3",
-    "@sito/dashboard": "^0.0.75",
     "@supabase/supabase-js": "2.100.0",
     "@tanstack/react-query": "5.83.0",
     "react": ">=18.2 <20",
@@ -108,7 +107,8 @@
     "vitest": "^3.2.1"
   },
   "dependencies": {
-    "some-javascript-utils": "^0.10.10"
+    "some-javascript-utils": "^0.10.10",
+    "@sito/dashboard": "^0.0.75"
   },
   "overrides": {
     "minimatch": "10.2.2"

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { Dialog } from "./Dialog";
+import { resetBodyScrollLockForTests } from "./bodyScrollLock";
+
+vi.mock("@sito/dashboard", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  classNames: (...values: Array<string | false | null | undefined>) =>
+    values.filter(Boolean).join(" "),
+}));
+
+vi.mock("components", () => ({
+  AppIconButton: ({
+    onClick,
+    ...props
+  }: {
+    onClick?: () => void;
+    [key: string]: unknown;
+  }) => <button type="button" onClick={onClick} {...props} />,
+}));
+
+describe("Dialog", () => {
+  beforeEach(() => {
+    resetBodyScrollLockForTests();
+  });
+
+  it("renders via portal and restores previous body overflow on unmount", () => {
+    document.body.style.overflow = "scroll";
+
+    const { unmount } = render(
+      <Dialog open title="Confirm" handleClose={vi.fn()}>
+        <p>Dialog body</p>
+      </Dialog>,
+    );
+
+    expect(screen.getByText("Dialog body")).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unmount();
+    expect(document.body.style.overflow).toBe("scroll");
+  });
+
+  it("calls handleClose on Escape when open", () => {
+    const handleClose = vi.fn();
+
+    render(
+      <Dialog open title="Confirm" handleClose={handleClose}>
+        <p>Dialog body</p>
+      </Dialog>,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(handleClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes only when backdrop is clicked", () => {
+    const handleClose = vi.fn();
+
+    render(
+      <Dialog open title="Confirm" handleClose={handleClose}>
+        <p>Dialog body</p>
+      </Dialog>,
+    );
+
+    fireEvent.click(screen.getByText("Dialog body"));
+    expect(handleClose).not.toHaveBeenCalled();
+
+    const backdrop = document.body.querySelector(".dialog-backdrop");
+    expect(backdrop).toBeInTheDocument();
+    if (backdrop) fireEvent.click(backdrop);
+
+    expect(handleClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -10,6 +10,7 @@ import { classNames } from "@sito/dashboard";
 
 // types
 import { DialogPropsType } from "./types";
+import { lockBodyScroll, unlockBodyScroll } from "./bodyScrollLock";
 
 // components
 import { AppIconButton } from "components";
@@ -56,16 +57,10 @@ export const Dialog = (props: DialogPropsType) => {
   );
 
   useEffect(() => {
-    const toggleBodyOverflow = (open: boolean) => {
-      if (open) {
-        document.body.style.overflow = "hidden";
-      } else {
-        document.body.style.overflow = "auto";
-      }
-    };
-    toggleBodyOverflow(open);
+    if (!open) return;
+    lockBodyScroll();
     return () => {
-      toggleBodyOverflow(false);
+      unlockBodyScroll();
     };
   }, [open]);
 

--- a/src/components/Dialog/bodyScrollLock.test.ts
+++ b/src/components/Dialog/bodyScrollLock.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  lockBodyScroll,
+  resetBodyScrollLockForTests,
+  unlockBodyScroll,
+} from "./bodyScrollLock";
+
+describe("bodyScrollLock", () => {
+  beforeEach(() => {
+    resetBodyScrollLockForTests();
+  });
+
+  it("restores previous overflow value after unlock", () => {
+    document.body.style.overflow = "scroll";
+
+    lockBodyScroll();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("scroll");
+  });
+
+  it("keeps body locked until all concurrent locks are released", () => {
+    document.body.style.overflow = "visible";
+
+    lockBodyScroll();
+    lockBodyScroll();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("visible");
+  });
+
+  it("does not alter overflow when unlocking without active locks", () => {
+    document.body.style.overflow = "clip";
+
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("clip");
+  });
+});

--- a/src/components/Dialog/bodyScrollLock.ts
+++ b/src/components/Dialog/bodyScrollLock.ts
@@ -1,0 +1,47 @@
+let lockCount = 0;
+let previousOverflow: string | null = null;
+
+const hasBody = () => typeof document !== "undefined" && !!document.body;
+
+/**
+ * Locks body scroll while preserving previous inline overflow style.
+ * Multiple callers can lock concurrently; body is restored on final unlock.
+ */
+export const lockBodyScroll = () => {
+  if (!hasBody()) return;
+
+  if (lockCount === 0) {
+    previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+
+  lockCount += 1;
+};
+
+/**
+ * Releases one body scroll lock.
+ * Restores previous overflow only when all locks are released.
+ */
+export const unlockBodyScroll = () => {
+  if (!hasBody()) return;
+  if (lockCount === 0) return;
+
+  lockCount -= 1;
+
+  if (lockCount === 0) {
+    document.body.style.overflow = previousOverflow ?? "";
+    previousOverflow = null;
+  }
+};
+
+/**
+ * Test-only helper to reset lock state between specs.
+ */
+export const resetBodyScrollLockForTests = () => {
+  lockCount = 0;
+  previousOverflow = null;
+
+  if (hasBody()) {
+    document.body.style.overflow = "";
+  }
+};

--- a/src/components/Navbar/Navbar.test.tsx
+++ b/src/components/Navbar/Navbar.test.tsx
@@ -151,6 +151,23 @@ describe("NavbarProvider", () => {
     expect(screen.getByTestId("child")).toBeInTheDocument();
   });
 
+  it("throws when useNavbar is called outside provider", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const Consumer = () => {
+      useNavbar();
+      return null;
+    };
+
+    expect(() => render(<Consumer />)).toThrow(
+      "useNavbar must be used within NavbarProvider",
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it("provides default empty title — navbar falls back to app name key", () => {
     renderWithProvider(<Navbar {...baseProps} />);
     expect(

--- a/src/components/Navbar/NavbarProvider.tsx
+++ b/src/components/Navbar/NavbarProvider.tsx
@@ -10,12 +10,7 @@ import {
 // types
 import { NavbarContextType, NavbarProviderPropTypes } from "./types.js";
 
-const NavbarContext = createContext<NavbarContextType>({
-  title: "",
-  setTitle: () => {},
-  rightContent: null,
-  setRightContent: () => {},
-});
+const NavbarContext = createContext<NavbarContextType | undefined>(undefined);
 
 /**
  * Navbar Provider
@@ -53,9 +48,14 @@ const NavbarProvider = (props: NavbarProviderPropTypes) => {
 
 /**
  * useNavbar hook
- * @returns Navbar context
+ * @returns {NavbarContextType} Navbar context values.
+ * @throws {Error} If used outside `NavbarProvider`.
  */
-const useNavbar = () => useContext(NavbarContext);
+const useNavbar = () => {
+  const context = useContext(NavbarContext);
+  if (!context) throw new Error("useNavbar must be used within NavbarProvider");
+  return context;
+};
 
 // eslint-disable-next-line react-refresh/only-export-components
 export { NavbarContext, NavbarProvider, useNavbar };

--- a/src/components/Notification/Notification.test.tsx
+++ b/src/components/Notification/Notification.test.tsx
@@ -1,0 +1,121 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Notification } from "./Notification";
+import { NotificationProvider, useNotification } from "providers";
+import { NotificationEnumType } from "lib";
+
+vi.mock("@sito/dashboard", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  classNames: (...values: Array<string | false | null | undefined>) =>
+    values.filter(Boolean).join(" "),
+}));
+
+vi.mock("../Buttons", () => ({
+  AppIconButton: ({
+    onClick,
+    className,
+    disabled,
+    type,
+    name,
+    "aria-label": ariaLabel,
+  }: {
+    onClick?: () => void;
+    className?: string;
+    disabled?: boolean;
+    type?: "button" | "submit" | "reset";
+    name?: string;
+    "aria-label"?: string;
+  }) => (
+    <button
+      type={type ?? "button"}
+      onClick={onClick}
+      className={className}
+      disabled={disabled}
+      name={name}
+      aria-label={ariaLabel}
+    />
+  ),
+}));
+
+const NotificationHarness = () => {
+  const { showSuccessNotification, showStackNotifications } = useNotification();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => showSuccessNotification({ message: "Saved" })}
+      >
+        Show one
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          showStackNotifications([
+            { message: "First", type: NotificationEnumType.info },
+            { message: "Second", type: NotificationEnumType.warning },
+          ])
+        }
+      >
+        Show stack
+      </button>
+      <Notification />
+    </>
+  );
+};
+
+describe("Notification", () => {
+  it("renders in portal and closes with Escape", () => {
+    vi.useFakeTimers();
+
+    render(
+      <NotificationProvider>
+        <NotificationHarness />
+      </NotificationProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show one" }));
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(screen.queryByText("Saved")).not.toBeInTheDocument();
+  });
+
+  it("closes stacked notifications on outside click", () => {
+    vi.useFakeTimers();
+
+    render(
+      <NotificationProvider>
+        <NotificationHarness />
+      </NotificationProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show stack" }));
+    act(() => {
+      vi.runAllTimers();
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+
+    fireEvent.click(window);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(screen.queryByText("First")).not.toBeInTheDocument();
+    expect(screen.queryByText("Second")).not.toBeInTheDocument();
+  });
+});

--- a/src/hooks/dialogs/types.ts
+++ b/src/hooks/dialogs/types.ts
@@ -120,12 +120,12 @@ export interface TriggerFormDialogPropsType<TFormType extends FieldValues>
     | "onSubmit"
   > {
   openDialog: (params?: number | OpenFormDialogParamsType<TFormType>) => void;
-  control: Control<TFormType, any, any>;
+  control: Control<TFormType, unknown, TFormType>;
   getValues: UseFormGetValues<TFormType>;
   setValue: UseFormSetValue<TFormType>;
   reset: UseFormReset<TFormType>;
   setError: UseFormSetError<TFormType>;
-  handleSubmit: UseFormHandleSubmit<TFormType, any>;
+  handleSubmit: UseFormHandleSubmit<TFormType, TFormType>;
   onSubmit: SubmitHandler<TFormType>;
 }
 

--- a/src/hooks/useTimeAge.tsx
+++ b/src/hooks/useTimeAge.tsx
@@ -12,7 +12,7 @@ export function useTimeAge() {
     (date: Date) => {
       const now = new Date();
 
-      const diffInMilliseconds = (now as any) - (date as any);
+      const diffInMilliseconds = now.getTime() - date.getTime();
       const diffInMinutes = Math.floor(diffInMilliseconds / (1000 * 60));
       const diffInHours = Math.floor(diffInMinutes / 60);
 

--- a/src/lib/api/utils/services.ts
+++ b/src/lib/api/utils/services.ts
@@ -40,6 +40,11 @@ const toHeaderRecord = (headers?: HeadersInit): Record<string, string> => {
   return headers;
 };
 
+const getObjectValue = (value: unknown, key: string): unknown => {
+  if (typeof value !== "object" || value === null) return undefined;
+  return (value as Record<string, unknown>)[key];
+};
+
 /**
  * @description Make a request to the API
  * @param url - URL to make the request
@@ -80,10 +85,14 @@ export async function makeRequest<TBody = undefined, TResponse = unknown>(
     }
 
     if (!response.ok) {
+      const parsedMessage = getObjectValue(parsed, "message");
+      const parsedError = getObjectValue(parsed, "error");
       const message =
-        typeof parsed === "object" && parsed !== null
-          ? ((parsed as any).message ?? (parsed as any).error ?? rawText)
-          : rawText || response.statusText;
+        typeof parsedMessage === "string" && parsedMessage.length
+          ? parsedMessage
+          : typeof parsedError === "string" && parsedError.length
+            ? parsedError
+            : rawText || response.statusText;
 
       return {
         data: null,

--- a/src/lib/utils/local.test.ts
+++ b/src/lib/utils/local.test.ts
@@ -22,6 +22,12 @@ describe("local storage utils", () => {
     expect(fromLocal("profile", "object")).toEqual({ id: 7, role: "admin" });
   });
 
+  it("returns undefined when object parsing fails", () => {
+    localStorage.setItem("corrupted", "{invalid-json");
+
+    expect(fromLocal("corrupted", "object")).toBeUndefined();
+  });
+
   it("parses boolean values from string and numeric forms", () => {
     localStorage.setItem("enabled", "true");
     expect(fromLocal("enabled", "boolean")).toBe(true);
@@ -31,6 +37,12 @@ describe("local storage utils", () => {
 
     localStorage.setItem("enabled", "0");
     expect(fromLocal("enabled", "boolean")).toBe(false);
+  });
+
+  it("returns undefined for invalid numeric values", () => {
+    localStorage.setItem("amount", "abc");
+
+    expect(fromLocal("amount", "number")).toBeUndefined();
   });
 
   it("removes keys", () => {

--- a/src/lib/utils/local.ts
+++ b/src/lib/utils/local.ts
@@ -1,26 +1,49 @@
+type LocalStorageTransform = "" | "string" | "object" | "number" | "boolean";
+
+const safeParse = (value: string) => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+};
+
 /**
  * Fetch data from local storage
  * @param key - key to fetch
  * @param as - transform parameter
  * @returns value of key in local storage
  */
-export const fromLocal = (key: string, as = "") => {
+export function fromLocal(key: string): string | undefined;
+export function fromLocal(key: string, as: ""): string | undefined;
+export function fromLocal(key: string, as: "string"): string | undefined;
+export function fromLocal<T = unknown>(
+  key: string,
+  as: "object",
+): T | undefined;
+export function fromLocal(key: string, as: "number"): number | undefined;
+export function fromLocal(key: string, as: "boolean"): boolean | undefined;
+export function fromLocal<T = unknown>(
+  key: string,
+  as: LocalStorageTransform = "",
+): string | number | boolean | T | undefined {
   const result = localStorage.getItem(key) ?? undefined;
-  if (result && as.length) {
-    switch (as) {
-      case "object":
-        return JSON.parse(result);
-      case "number":
-        return Number(result);
-      case "boolean":
-        if (result === "true" || result === "1") return true;
-        return false;
-      default: // "string"
-        return result;
+  if (result === undefined) return undefined;
+  if (!as.length || as === "string") return result;
+
+  switch (as) {
+    case "object":
+      return safeParse(result) as T | undefined;
+    case "number": {
+      const parsed = Number(result);
+      return Number.isNaN(parsed) ? undefined : parsed;
     }
+    case "boolean":
+      return result === "true" || result === "1";
+    default:
+      return result;
   }
-  return result;
-};
+}
 
 /**
  * Save data to local storage
@@ -28,11 +51,13 @@ export const fromLocal = (key: string, as = "") => {
  * @param value - value to save
  * @returns nothing
  */
-export const toLocal = (key: string, value: any) =>
-  localStorage.setItem(
-    key,
-    typeof value === "object" ? JSON.stringify(value) : value,
-  );
+export const toLocal = (key: string, value: unknown) => {
+  if (value !== null && typeof value === "object") {
+    localStorage.setItem(key, JSON.stringify(value));
+    return;
+  }
+  localStorage.setItem(key, String(value));
+};
 
 /**
  * Remove data from local storage

--- a/src/lib/utils/navigation.ts
+++ b/src/lib/utils/navigation.ts
@@ -22,7 +22,7 @@ export interface Path {
  * An entry in a history stack. A location contains information about the
  * URL path, as well as possibly some arbitrary state and a key.
  */
-export interface Location<State = any> extends Path {
+export interface Location<State = unknown> extends Path {
   /**
    * A value of arbitrary data associated with this location.
    */

--- a/src/lib/utils/os.ts
+++ b/src/lib/utils/os.ts
@@ -3,7 +3,9 @@
  * @returns Whether the running platform is Apple-based.
  */
 export const isMac = () => {
-  const nav = navigator as any;
+  const nav = navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
   const platform = nav?.userAgentData?.platform || nav?.platform || "";
   return /Mac|iPhone|iPod|iPad/i.test(platform);
 };

--- a/src/providers/Auth/AuthProvider.test.tsx
+++ b/src/providers/Auth/AuthProvider.test.tsx
@@ -178,7 +178,7 @@ describe("AuthProvider", () => {
       .mockImplementation(() => undefined);
 
     expect(() => renderHook(() => useAuth())).toThrow(
-      "authContext must be used within a Provider",
+      "useAuthContext must be used within AuthProvider",
     );
 
     consoleErrorSpy.mockRestore();

--- a/src/providers/Auth/AuthProvider.tsx
+++ b/src/providers/Auth/AuthProvider.tsx
@@ -136,7 +136,7 @@ const AuthProvider = (props: AuthProviderPropTypes) => {
 
 /**
  * useAuth hook
- * @returns Provider
+ * @returns Auth context values from `AuthProvider`.
  */
 const useAuth = () => {
   return useAuthContext();

--- a/src/providers/Auth/authContext.ts
+++ b/src/providers/Auth/authContext.ts
@@ -10,11 +10,13 @@ export const AuthContext = createContext<AuthProviderContextType | undefined>(
 /**
  * Returns AuthContext value and throws when provider is missing.
  * @returns Required auth context value.
+ * @throws {Error} If used outside `AuthProvider`.
  */
 export const useAuthContext = () => {
   const context = useContext(AuthContext);
 
-  if (!context) throw new Error("authContext must be used within a Provider");
+  if (!context)
+    throw new Error("useAuthContext must be used within AuthProvider");
   return context;
 };
 

--- a/src/providers/BottomNavAction/useBottomNavAction.ts
+++ b/src/providers/BottomNavAction/useBottomNavAction.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useRef } from "react";
 import { BottomNavActionContext } from "./BottomNavActionContext";
 import type { BottomNavigationCenterActionType } from "components/BottomNavigation/types";
 
@@ -13,6 +13,35 @@ const normalizeBottomNavAction = (
   if (!action) return null;
   if (typeof action === "function") return { onClick: () => action() };
   return action;
+};
+
+const toActionRegistrationKey = (
+  action: BottomNavActionRegistrationType,
+): string => {
+  if (!action) return "null";
+  if (typeof action === "function") return "function";
+
+  const { onClick, icon, ...rest } = action;
+  const toComparableString = (value: unknown) => {
+    if (typeof value === "function") return "__function__";
+
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  };
+
+  const stableRest = Object.entries(rest)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}:${toComparableString(value)}`)
+    .join("|");
+
+  return [
+    `rest=${stableRest}`,
+    `hasOnClick=${typeof onClick === "function"}`,
+    `icon=${icon ? `${icon.prefix}:${icon.iconName}` : "null"}`,
+  ].join(";");
 };
 
 /**
@@ -42,9 +71,35 @@ export const useRegisterBottomNavAction = (
   action: BottomNavActionRegistrationType,
 ) => {
   const { setCenterAction } = useBottomNavAction();
+  const latestActionRef = useRef<BottomNavActionRegistrationType>(action);
+  const registrationKey = toActionRegistrationKey(action);
 
   useEffect(() => {
-    setCenterAction(normalizeBottomNavAction(action));
+    latestActionRef.current = action;
+  }, [action]);
+
+  useEffect(() => {
+    const normalizedAction = normalizeBottomNavAction(latestActionRef.current);
+
+    if (!normalizedAction) {
+      setCenterAction(null);
+      return;
+    }
+
+    setCenterAction({
+      ...normalizedAction,
+      onClick: normalizedAction.onClick
+        ? (event) => {
+            const latestAction = normalizeBottomNavAction(
+              latestActionRef.current,
+            );
+            latestAction?.onClick?.(event);
+          }
+        : undefined,
+    });
+  }, [registrationKey, setCenterAction]);
+
+  useEffect(() => {
     return () => setCenterAction(null);
-  }, [action, setCenterAction]);
+  }, [setCenterAction]);
 };

--- a/src/providers/ConfigProvider.test.tsx
+++ b/src/providers/ConfigProvider.test.tsx
@@ -61,7 +61,7 @@ describe("ConfigProvider", () => {
       .mockImplementation(() => undefined);
 
     expect(() => render(<Consumer />)).toThrow(
-      "Config provider has not been set.",
+      "useConfig must be used within ConfigProvider",
     );
 
     consoleErrorSpy.mockRestore();

--- a/src/providers/ConfigProvider.tsx
+++ b/src/providers/ConfigProvider.tsx
@@ -3,7 +3,9 @@ import { createContext, useContext } from "react";
 // config
 import { ConfigProviderContextType, ConfigProviderPropTypes } from "./types";
 
-const ConfigContext = createContext({} as ConfigProviderContextType);
+const ConfigContext = createContext<ConfigProviderContextType | undefined>(
+  undefined,
+);
 
 /**
  * Config Provider
@@ -25,14 +27,12 @@ const ConfigProvider = (props: ConfigProviderPropTypes) => {
 
 /**
  * useConfig hook
- * @returns Provider
+ * @returns {ConfigProviderContextType} Config context values.
+ * @throws {Error} If used outside `ConfigProvider`.
  */
 const useConfig = () => {
   const context = useContext(ConfigContext);
-  if (context === undefined || Object.keys(context).length === 0)
-    throw new Error(
-      "Config provider has not been set. This step is required and cannot be skipped.",
-    );
+  if (!context) throw new Error("useConfig must be used within ConfigProvider");
   return context;
 };
 

--- a/src/providers/DrawerMenuProvider.tsx
+++ b/src/providers/DrawerMenuProvider.tsx
@@ -85,7 +85,7 @@ const DrawerMenuProvider = <MenuKeys extends string>(
 
 /**
  * useDrawerMenu hook
- * @returns Provider
+ * @returns {DrawerMenuContextType<MenuKeys>} Drawer menu context values.
  */
 const useDrawerMenu = <MenuKeys extends string>() => {
   const context = useContext(DrawerMenuContext);

--- a/src/providers/ManagerProvider.test.tsx
+++ b/src/providers/ManagerProvider.test.tsx
@@ -31,7 +31,7 @@ describe("ManagerProvider", () => {
       .mockImplementation(() => undefined);
 
     expect(() => renderHook(() => useManager())).toThrow(
-      "managerContext must be used within a Provider",
+      "useManager must be used within ManagerProvider",
     );
 
     consoleErrorSpy.mockRestore();

--- a/src/providers/ManagerProvider.tsx
+++ b/src/providers/ManagerProvider.tsx
@@ -44,13 +44,14 @@ const ManagerProvider = (props: ManagerProviderPropTypes) => {
 
 /**
  * useManager hook
- * @returns Provider
+ * @returns Manager client from context.
+ * @throws {Error} If used outside `ManagerProvider`.
  */
 const useManager = () => {
   const context = useContext(ManagerContext);
 
   if (!context)
-    throw new Error("managerContext must be used within a Provider");
+    throw new Error("useManager must be used within ManagerProvider");
   return context.client;
 };
 

--- a/src/providers/NotificationProvider.test.tsx
+++ b/src/providers/NotificationProvider.test.tsx
@@ -15,7 +15,7 @@ describe("NotificationProvider", () => {
       .mockImplementation(() => undefined);
 
     expect(() => renderHook(() => useNotification())).toThrow(
-      "NotificationContext must be used within a Provider",
+      "useNotification must be used within NotificationProvider",
     );
 
     consoleErrorSpy.mockRestore();

--- a/src/providers/NotificationProvider.tsx
+++ b/src/providers/NotificationProvider.tsx
@@ -111,13 +111,19 @@ export function NotificationProvider(props: BasicProviderPropTypes) {
 }
 
 /**
+ * Hook to consume the notification context.
  *
- * @returns notification context
+ * @returns {NotificationContextType} Notification state and helper methods.
+ * `notification` is `NotificationType[]`.
+ * `showNotification` receives `NotificationType`.
+ * `showSuccessNotification` and `showErrorNotification` receive `Partial<NotificationType>`.
+ * `showStackNotifications` receives `NotificationType[]`.
+ * @throws {Error} If used outside `NotificationProvider`.
  */
-export const useNotification = () => {
+export const useNotification = (): NotificationContextType => {
   const context = useContext(NotificationContext);
 
   if (!context)
-    throw new Error("NotificationContext must be used within a Provider");
+    throw new Error("useNotification must be used within NotificationProvider");
   return context;
 };

--- a/src/providers/Supbase/SupabaseContext.ts
+++ b/src/providers/Supbase/SupabaseContext.ts
@@ -9,11 +9,12 @@ export const SupabaseManagerContext = createContext<
 /**
  * Returns the Supabase client from context and enforces provider usage.
  * @returns Supabase manager client.
+ * @throws {Error} If used outside `SupabaseManagerProvider`.
  */
 export const useSupabase = () => {
   const context = useContext(SupabaseManagerContext);
 
   if (!context)
-    throw new Error("supabaseManagerContext must be used within a Provider");
+    throw new Error("useSupabase must be used within SupabaseManagerProvider");
   return context.client;
 };

--- a/src/providers/Supbase/SupabaseManagerProvider.test.tsx
+++ b/src/providers/Supbase/SupabaseManagerProvider.test.tsx
@@ -35,7 +35,7 @@ describe("SupabaseManagerProvider", () => {
       .mockImplementation(() => undefined);
 
     expect(() => renderHook(() => useSupabase())).toThrow(
-      "supabaseManagerContext must be used within a Provider",
+      "useSupabase must be used within SupabaseManagerProvider",
     );
 
     consoleErrorSpy.mockRestore();


### PR DESCRIPTION
## [0.0.62] - 2026-04-09

### Changed

- Moved `@sito/dashboard@^0.0.75` from `peerDependencies` to `dependencies` so consumer apps do not fail with unresolved `@sito/dashboard` when only installing `@sito/dashboard-app`.
- Tightened provider/context hook contracts:
  - `useConfig` now uses an `undefined` default context and throws `useConfig must be used within ConfigProvider` when missing.
  - `useManager`, `useAuthContext`, `useNotification`, and `useSupabase` now expose consistent provider-specific error messages.
  - `useNavbar` now throws when `NavbarProvider` is missing instead of silently using no-op defaults.
- Improved provider hook inline docs (JSDoc) with explicit return types and `@throws` semantics.
- Updated related test expectations to match the new error messages and added explicit coverage for `useNavbar` outside `NavbarProvider`.

### Fixed

- Fixed `useRegisterBottomNavAction` stability when consumers pass inline action objects:
  - registration now derives a stable comparison key to avoid unnecessary re-registration churn.
  - hook cleanup now runs on unmount via a dedicated effect.
- Fixed React ref render-phase mutation warning by moving `latestActionRef` synchronization to an effect instead of mutating `ref.current` during render.