### PR TITLE
0.0.66

### DIFF
--- a/.sito/README.md
+++ b/.sito/README.md
@@ -18,4 +18,4 @@ Canonical docs for this repository:
 Base compatibility:
 
 - `react` / `react-dom` `>=18.2 <20`
-- `@sito/dashboard` `0.0.78`
+- `@sito/dashboard` `0.0.80`

--- a/.sito/usage-guide.md
+++ b/.sito/usage-guide.md
@@ -391,6 +391,20 @@ const options: Option[] = [
 />;
 ```
 
+For custom upload UIs (for example profile photo pickers), render only the native input:
+
+```tsx
+<FileInput
+  id="profile-photo-file-input"
+  unstyled
+  inputClassName="hidden"
+  accept="image/jpeg,image/png,image/webp"
+  onChange={(e) => onUpload(e.currentTarget.files?.[0] ?? null)}
+/>
+```
+
+`hiddenContainer` is available as an alias of `unstyled`.
+
 `Option` shape expected by selection components:
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard-app",
-  "version": "0.0.64",
+  "version": "0.0.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard-app",
-      "version": "0.0.64",
+      "version": "0.0.66",
       "license": "MIT",
       "dependencies": {
         "@sito/dashboard": "^0.0.79",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard-app",
   "private": false,
-  "version": "0.0.64",
+  "version": "0.0.66",
   "type": "module",
   "description": "UI Library with prefab components",
   "main": "dist/dashboard-app.cjs",

--- a/src/hooks/dialogs/useFormDialog.tsx
+++ b/src/hooks/dialogs/useFormDialog.tsx
@@ -98,7 +98,7 @@ export const useFormDialog = <
       }
 
       setId(nextId);
-      if (nextValues) {
+      if (nextValues !== undefined) {
         if (open) {
           reset(nextValues);
         } else {

--- a/src/hooks/dialogs/usePutDialog.test.tsx
+++ b/src/hooks/dialogs/usePutDialog.test.tsx
@@ -41,6 +41,43 @@ const createWrapper = () => {
 };
 
 describe("usePutDialog", () => {
+  it("supports id = 0 when loading entity data", async () => {
+    const getFunction = vi.fn(async (id: number) => ({
+      id,
+      name: "Zero Product",
+    }));
+
+    const mutationFn = vi.fn(async (payload: ProductUpdateDto) => payload);
+
+    const { result } = renderHook(
+      () =>
+        usePutDialog<
+          ProductDto,
+          ProductUpdateDto,
+          ProductUpdateDto,
+          ProductForm
+        >({
+          title: "Edit product",
+          defaultValues: { name: "" },
+          getFunction,
+          mutationFn,
+          dtoToForm: (dto) => ({ name: dto.name }),
+          formToDto: (values, dto) => ({ id: dto?.id, name: values.name }),
+          queryKey: ["products"],
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.openDialog(0);
+    });
+
+    await waitFor(() => {
+      expect(getFunction).toHaveBeenCalledWith(0);
+      expect(result.current.getValues().name).toBe("Zero Product");
+    });
+  });
+
   it("loads by id and submits mapped update payload", async () => {
     const getFunction = vi.fn(async (id: number) => ({
       id,
@@ -84,5 +121,67 @@ describe("usePutDialog", () => {
     await waitFor(() => {
       expect(mutationFn).toHaveBeenCalledWith({ id: 7, name: "Updated" });
     });
+  });
+
+  it("rehydrates cached data when reopening the same id", async () => {
+    const cachedEntity: ProductDto = { id: 7, name: "Remote Product" };
+    const getFunction = vi.fn(async () => cachedEntity);
+    const mutationFn = vi.fn(async (payload: ProductUpdateDto) => payload);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: Number.POSITIVE_INFINITY,
+        },
+      },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePutDialog<
+          ProductDto,
+          ProductUpdateDto,
+          ProductUpdateDto,
+          ProductForm
+        >({
+          title: "Edit product",
+          defaultValues: { name: "" },
+          getFunction,
+          mutationFn,
+          dtoToForm: (dto) => ({ name: dto.name }),
+          formToDto: (values, dto) => ({ id: dto?.id, name: values.name }),
+          queryKey: ["products"],
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.openDialog(7);
+    });
+
+    await waitFor(() => {
+      expect(result.current.getValues().name).toBe("Remote Product");
+    });
+
+    act(() => {
+      result.current.setValue("name", "Locally edited");
+      result.current.handleClose();
+    });
+
+    await waitFor(() => {
+      expect(result.current.open).toBe(false);
+    });
+
+    act(() => {
+      result.current.openDialog(7);
+    });
+
+    await waitFor(() => {
+      expect(result.current.getValues().name).toBe("Remote Product");
+    });
+    expect(getFunction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/dialogs/usePutDialog.tsx
+++ b/src/hooks/dialogs/usePutDialog.tsx
@@ -25,7 +25,6 @@ export const usePutDialog = <
 ): UseFormDialogReturnType<TFormType> => {
   const queryClient = useQueryClient();
   const entityRef = useRef<TDto>();
-  const lastHydratedDataRef = useRef<TDto>();
 
   const {
     mutationFn,
@@ -75,19 +74,18 @@ export const usePutDialog = <
   const { reset: resetForm } = dialog;
 
   const resolveQueryKey = queryKey || ["put-dialog", title];
+  const hasDialogId = typeof dialog.id === "number";
 
   const getByIdQuery = useQuery({
     queryFn: () => getFunction(dialog.id as number),
     queryKey: [...resolveQueryKey, dialog.id],
-    enabled: dialog.open && !!dialog.id,
+    enabled: dialog.open && hasDialogId,
   });
 
   useEffect(() => {
-    if (!getByIdQuery.data) return;
-    if (lastHydratedDataRef.current === getByIdQuery.data) return;
+    if (!dialog.open || !getByIdQuery.data) return;
 
     entityRef.current = getByIdQuery.data;
-    lastHydratedDataRef.current = getByIdQuery.data;
 
     if (dtoToFormRef.current && resetForm) {
       resetForm(dtoToFormRef.current(getByIdQuery.data));
@@ -95,7 +93,12 @@ export const usePutDialog = <
     }
 
     resetForm?.(getByIdQuery.data as unknown as TFormType);
-  }, [getByIdQuery.data, resetForm]);
+  }, [dialog.open, getByIdQuery.data, resetForm]);
+
+  useEffect(() => {
+    if (dialog.open) return;
+    entityRef.current = undefined;
+  }, [dialog.open]);
 
   return {
     ...dialog,

--- a/src/lib/api/IndexedDBClient.test.ts
+++ b/src/lib/api/IndexedDBClient.test.ts
@@ -190,6 +190,18 @@ describe("User", () => {
     expect(page1.items[0]!.name).toBe("User3");
   });
 
+  it("get falls back to default pagination when pageSize is 0", async () => {
+    await client.insert({ name: "Alice", email: "alice@test.com" });
+    await client.insert({ name: "Bob", email: "bob@test.com" });
+
+    const result = await client.get({ pageSize: 0, currentPage: 0 });
+
+    expect(result.pageSize).toBe(10);
+    expect(result.totalPages).toBe(1);
+    expect(result.totalPages).not.toBe(Infinity);
+    expect(result.items).toHaveLength(2);
+  });
+
   it("get sorts by field ascending and descending", async () => {
     await client.insert({ name: "Zara", email: "z@test.com" });
     await client.insert({ name: "Ana", email: "a@test.com" });

--- a/src/lib/api/IndexedDBClient.test.ts
+++ b/src/lib/api/IndexedDBClient.test.ts
@@ -158,6 +158,12 @@ describe("User", () => {
     expect(result.totalElements).toBe(3);
   });
 
+  it("insertMany throws when receiving an empty array", async () => {
+    await expect(client.insertMany([])).rejects.toThrow(
+      "insertMany requires items",
+    );
+  });
+
   it("get returns paginated result with defaults", async () => {
     await client.insert({ name: "Alice", email: "alice@test.com" });
     await client.insert({ name: "Bob", email: "bob@test.com" });

--- a/src/lib/api/IndexedDBClient.ts
+++ b/src/lib/api/IndexedDBClient.ts
@@ -94,6 +94,8 @@ export class IndexedDBClient<
   }
 
   async insertMany(data: TAddDto[]): Promise<TDto> {
+    if (data.length === 0) throw new Error("insertMany requires items");
+
     const store = await this.transaction("readwrite");
     let lastId: IDBValidKey = 0;
     for (const item of data) {

--- a/src/lib/api/IndexedDBClient.ts
+++ b/src/lib/api/IndexedDBClient.ts
@@ -146,7 +146,11 @@ export class IndexedDBClient<
       return 0;
     });
 
-    const pageSize = query?.pageSize ?? 10;
+    const requestedPageSize = query?.pageSize;
+    const pageSize =
+      typeof requestedPageSize === "number" && requestedPageSize > 0
+        ? requestedPageSize
+        : 10;
     const currentPage = query?.currentPage ?? 0;
     const totalElements = filtered.length;
     const totalPages = Math.ceil(totalElements / pageSize);

--- a/src/lib/api/SupabaseDataClient.test.ts
+++ b/src/lib/api/SupabaseDataClient.test.ts
@@ -261,6 +261,27 @@ describe("SupabaseDataClient", () => {
     expect(result.items[0]?.id).toBe(1);
   });
 
+  it("get skips object filters when id is missing or empty", async () => {
+    const listBuilder = createFilterBuilder<ProductRow>({
+      data: [baseRow],
+      error: null,
+      count: 1,
+      status: 200,
+    });
+
+    const fromMock = vi.fn(() => ({
+      select: vi.fn(() => listBuilder),
+    }));
+
+    const client = createClient(asSupabaseFromClient(fromMock));
+
+    await client.get(undefined, {
+      category: { label: "no-id" } as unknown as { id: number },
+    });
+
+    expect(listBuilder.eq).not.toHaveBeenCalled();
+  });
+
   it("get maps softDeleteScope=DELETED to not-is-null", async () => {
     const listBuilder = createFilterBuilder<ProductRow>({
       data: [baseRow],

--- a/src/lib/api/SupabaseDataClient.ts
+++ b/src/lib/api/SupabaseDataClient.ts
@@ -201,9 +201,16 @@ export class SupabaseDataClient<
     return value as unknown as Partial<TRow>;
   }
 
-  private resolveObjectFilterValue(value: Record<string, unknown>): unknown {
-    if ("id" in value) return normalizeScalarValue(value.id);
-    return "";
+  private resolveObjectFilterValue(
+    value: Record<string, unknown>,
+  ): unknown | undefined {
+    if (!("id" in value)) return undefined;
+
+    const normalized = normalizeScalarValue(value.id);
+    if (normalized === undefined || normalized === null || normalized === "")
+      return undefined;
+
+    return normalized;
   }
 
   private applyFilters<TBuilder extends FilterBuilder<TBuilder>>(
@@ -264,10 +271,10 @@ export class SupabaseDataClient<
       }
 
       if (isRecord(filterValue)) {
-        scopedBuilder = scopedBuilder.eq(
-          column,
-          this.resolveObjectFilterValue(filterValue),
-        );
+        const resolvedValue = this.resolveObjectFilterValue(filterValue);
+        if (!isDefined(resolvedValue)) return;
+
+        scopedBuilder = scopedBuilder.eq(column, resolvedValue);
         return;
       }
 

--- a/src/lib/api/utils/query.test.ts
+++ b/src/lib/api/utils/query.test.ts
@@ -5,7 +5,11 @@ import { parseQueries } from "./query";
 import type { BaseEntityDto, BaseFilterDto } from "lib";
 
 type UserDto = BaseEntityDto & { name: string };
-type UserFilterDto = BaseFilterDto & { status?: string };
+type UserFilterDto = BaseFilterDto & {
+  status?: string;
+  category?: { id?: number; label?: string };
+  categories?: Array<{ id?: number; label?: string }>;
+};
 
 describe("parseQueries", () => {
   it("does not serialize undefined query fields", () => {
@@ -46,5 +50,14 @@ describe("parseQueries", () => {
     expect(result).toContain(
       `filters=deletedAt==${encodeURIComponent(deletedAt.toISOString())}`,
     );
+  });
+
+  it("skips object filters when id is missing or empty", () => {
+    const result = parseQueries<UserDto, UserFilterDto>("/users", undefined, {
+      category: { label: "no-id" },
+      categories: [{ id: 7 }, { label: "missing-id" }, { id: undefined }],
+    });
+
+    expect(result).toBe("/users?filters=categories==7");
   });
 });

--- a/src/lib/api/utils/query.ts
+++ b/src/lib/api/utils/query.ts
@@ -13,6 +13,13 @@ const toEncodedScalar = (value: unknown): string => {
   return encodeURIComponent(String(value));
 };
 
+const resolveObjectId = (value: Record<string, unknown>): unknown => {
+  if (!("id" in value)) return undefined;
+  if (value.id === undefined || value.id === null || value.id === "")
+    return undefined;
+  return value.id;
+};
+
 const resolveSoftDeleteScope = (value: unknown) => {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim().toUpperCase();
@@ -64,9 +71,13 @@ export const parseQueries = <TDto, TFilter extends BaseFilterDto>(
       .flatMap(([key, value]) => {
         // Multiple values (array)
         if (Array.isArray(value)) {
-          return value.map((v) => {
+          return value.flatMap((v) => {
             if (v instanceof Date) return `${key}==${toEncodedScalar(v)}`;
-            if (isRecord(v)) return `${key}==${toEncodedScalar(v.id ?? "")}`;
+            if (isRecord(v)) {
+              const resolvedId = resolveObjectId(v);
+              if (resolvedId === undefined) return [];
+              return `${key}==${toEncodedScalar(resolvedId)}`;
+            }
             return `${key}==${toEncodedScalar(v)}`;
           });
         }
@@ -81,10 +92,12 @@ export const parseQueries = <TDto, TFilter extends BaseFilterDto>(
           return range;
         }
 
-        // Object with `id` fallback
+        // Object filters only apply when a non-empty `id` is available
         if (value instanceof Date) return `${key}==${toEncodedScalar(value)}`;
         if (isRecord(value)) {
-          return `${key}==${toEncodedScalar(value.id ?? "")}`;
+          const resolvedId = resolveObjectId(value);
+          if (resolvedId === undefined) return [];
+          return `${key}==${toEncodedScalar(resolvedId)}`;
         }
 
         // Primitive

--- a/src/lib/entities/auth/SessionDto.ts
+++ b/src/lib/entities/auth/SessionDto.ts
@@ -6,3 +6,5 @@ export type SessionDto = {
   refreshToken?: string | null;
   accessTokenExpiresAt?: string | null;
 };
+
+export type SessionAccountDto = Partial<SessionDto>;

--- a/src/lib/utils/navigation.ts
+++ b/src/lib/utils/navigation.ts
@@ -26,14 +26,14 @@ export interface Location<State = unknown> extends Path {
   /**
    * A value of arbitrary data associated with this location.
    */
-  state: State;
+  state?: State;
   /**
    * A unique string associated with this location. May be used to safely store
    * and retrieve data in some other storage API, like `localStorage`.
    *
    * Note: This value is always "default" on the initial location.
    */
-  key: string;
+  key?: string;
 }
 
 export type ViewPageType<PageId> = {

--- a/src/providers/Auth/AuthProvider.test.tsx
+++ b/src/providers/Auth/AuthProvider.test.tsx
@@ -158,6 +158,40 @@ describe("AuthProvider", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("waits for logout completion when session recovery fails", async () => {
+    getSessionMock.mockRejectedValue(new Error("Session expired"));
+    let resolveLogout: (() => void) | undefined;
+    logoutMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogout = resolve;
+        }),
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    const logUserFromLocalPromise = result.current.logUserFromLocal();
+    let settled = false;
+    void logUserFromLocalPromise.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(logoutMock).toHaveBeenCalledOnce();
+    expect(settled).toBe(false);
+
+    await act(async () => {
+      resolveLogout?.();
+      await logUserFromLocalPromise;
+    });
+
+    expect(settled).toBe(true);
+    consoleErrorSpy.mockRestore();
+  });
+
   it("detects guest mode only when enabled and no token is loaded", () => {
     const { result } = renderHook(() => useAuth(), { wrapper });
 

--- a/src/providers/Auth/AuthProvider.tsx
+++ b/src/providers/Auth/AuthProvider.tsx
@@ -8,7 +8,13 @@ import { AuthContext, useAuthContext } from "./authContext";
 import { useManager } from "../ManagerProvider";
 
 // lib
-import { toLocal, removeFromLocal, fromLocal, SessionDto } from "lib";
+import {
+  toLocal,
+  removeFromLocal,
+  fromLocal,
+  SessionAccountDto,
+  SessionDto,
+} from "lib";
 
 /**
  * Auth Provider
@@ -27,7 +33,7 @@ const AuthProvider = (props: AuthProviderPropTypes) => {
 
   const manager = useManager();
 
-  const [account, setAccount] = useState<SessionDto>({} as SessionDto);
+  const [account, setAccount] = useState<SessionAccountDto>({});
 
   const clearStoredSession = useCallback(() => {
     removeFromLocal(user);
@@ -92,7 +98,7 @@ const AuthProvider = (props: AuthProviderPropTypes) => {
     } catch (err) {
       console.error(err);
     }
-    setAccount({} as SessionDto);
+    setAccount({});
     clearStoredSession();
   }, [
     account.refreshToken,
@@ -109,7 +115,7 @@ const AuthProvider = (props: AuthProviderPropTypes) => {
       logUser(authDto);
     } catch (err) {
       console.error(err);
-      logoutUser();
+      await logoutUser();
     }
   }, [logUser, logoutUser, manager.Auth]);
 

--- a/src/providers/Auth/types.ts
+++ b/src/providers/Auth/types.ts
@@ -1,4 +1,4 @@
-import { SessionDto } from "lib";
+import { SessionAccountDto, SessionDto } from "lib";
 import { BasicProviderPropTypes } from "providers";
 
 export interface AuthProviderPropTypes extends BasicProviderPropTypes {
@@ -10,7 +10,7 @@ export interface AuthProviderPropTypes extends BasicProviderPropTypes {
 }
 
 export type AuthProviderContextType = {
-  account: SessionDto;
+  account: SessionAccountDto;
   logUser: (data: SessionDto, rememberMe?: boolean) => void;
   logoutUser: () => Promise<void>;
   logUserFromLocal: () => Promise<void>;

--- a/src/providers/ConfigProvider.test.tsx
+++ b/src/providers/ConfigProvider.test.tsx
@@ -10,8 +10,6 @@ const mockLocation: Location = {
   pathname: "/dashboard",
   search: "",
   hash: "",
-  state: null,
-  key: "default",
 };
 
 const LinkComponent = ({ to, children, ...props }: BaseLinkPropsType) => {

--- a/src/providers/Supabase/SupabaseAuthProvider.tsx
+++ b/src/providers/Supabase/SupabaseAuthProvider.tsx
@@ -8,6 +8,7 @@ import {
   fromLocal,
   mapSupabaseSessionToSessionDto,
   removeFromLocal,
+  SessionAccountDto,
   SessionDto,
   toLocal,
 } from "lib";
@@ -30,7 +31,7 @@ const SupabaseAuthProvider = (props: SupabaseAuthProviderPropTypes) => {
     mapperRef.current = sessionMapper ?? mapSupabaseSessionToSessionDto;
   }, [sessionMapper]);
 
-  const [account, setAccount] = useState<SessionDto>({} as SessionDto);
+  const [account, setAccount] = useState<SessionAccountDto>({});
 
   const clearStoredSession = useCallback(() => {
     removeFromLocal(user);
@@ -85,7 +86,7 @@ const SupabaseAuthProvider = (props: SupabaseAuthProviderPropTypes) => {
       console.error(err);
     }
 
-    setAccount({} as SessionDto);
+    setAccount({});
     clearStoredSession();
   }, [clearStoredSession, supabase.auth]);
 
@@ -95,7 +96,7 @@ const SupabaseAuthProvider = (props: SupabaseAuthProviderPropTypes) => {
       if (error) throw error;
 
       if (!data.session) {
-        setAccount({} as SessionDto);
+        setAccount({});
         clearStoredSession();
         return;
       }
@@ -121,7 +122,7 @@ const SupabaseAuthProvider = (props: SupabaseAuthProviderPropTypes) => {
       if (!mounted) return;
 
       if (!session) {
-        setAccount({} as SessionDto);
+        setAccount({});
         clearStoredSession();
         return;
       }


### PR DESCRIPTION
## [0.0.66] - 2026-04-15

### Changed

- Bumped package version to `0.0.66`.

### Known Issues

- `usePutDialog` can skip hydration when reopening the same entity id because repeated cached references are ignored, and query hydration is also disabled when `id = 0` (`enabled: dialog.open && !!dialog.id`).
- `BaseEntityDto` declares `createdAt`/`updatedAt`/`deletedAt` as `Date`, but the default REST client path returns parsed JSON payloads without date normalization, creating a runtime/type-contract mismatch for consumers.
- `AuthProvider` and `SupabaseAuthProvider` initialize and clear session state with `{}` cast to `SessionDto`, so fields typed as required may be absent at runtime; additionally, `AuthProvider.logUserFromLocal` does not await `logoutUser()` in its error path.
- `IndexedDBClient.insertMany([])` does not guard empty batches and can return an invalid synthetic DTO (`id: 0` + undefined payload shape) instead of failing fast.
- Query/object filter handling serializes object filters without `id` as empty-string equality (`field==""` / `eq(field, "")`), which can produce unintended filtering behavior in both REST query serialization and Supabase filtering.
- `Location` type requires `state` and `key`, but docs/examples use `window.location`, causing TypeScript contract friction in strict consumer projects.
- `IndexedDBClient.get` computes `totalPages` as `Math.ceil(totalElements / pageSize)` without guarding `pageSize = 0`, which can yield `Infinity`.