### PR TITLE
0.0.69

### DIFF
--- a/.sito/README.md
+++ b/.sito/README.md
@@ -18,4 +18,4 @@ Canonical docs for this repository:
 Base compatibility:
 
 - `react` / `react-dom` `>=18.2 <20`
-- `@sito/dashboard` `0.0.80`
+- `@sito/dashboard` `0.0.81`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Critical distinction:
 | Icons        | FontAwesome          | 7.0.0   |
 | Forms        | React Hook Form      | 7.61.1  |
 | Server State | TanStack React Query | 5.x     |
-| Base Library | @sito/dashboard      | ^0.0.80 |
+| Base Library | @sito/dashboard      | ^0.0.81 |
 
 ---
 
@@ -50,7 +50,7 @@ All peer dependencies **must** be installed in the consumer project:
 ```bash
 npm install \
   react@18.3.1 react-dom@18.3.1 \
-  @sito/dashboard@^0.0.80 \
+  @sito/dashboard@^0.0.81 \
   @tanstack/react-query@5.83.0 \
   react-hook-form@7.61.1 \
   @fortawesome/fontawesome-svg-core@7.0.0 \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pnpm add @sito/dashboard-app
 - `@tanstack/react-query` `5.83.0`
 - `@supabase/supabase-js` `2.100.0` (optional; only if using Supabase backend)
 - `react-hook-form` `7.61.1`
-- `@sito/dashboard` `^0.0.80`
+- `@sito/dashboard` `^0.0.81`
 - Font Awesome peers defined in `package.json`
 
 Install all peers in consumer apps:
@@ -49,7 +49,7 @@ Install all peers in consumer apps:
 ```bash
 npm install \
   react@18.3.1 react-dom@18.3.1 \
-  @sito/dashboard@^0.0.80 \
+  @sito/dashboard@^0.0.81 \
   @tanstack/react-query@5.83.0 \
   react-hook-form@7.61.1 \
   @fortawesome/fontawesome-svg-core@7.0.0 \

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -13,7 +13,7 @@ Install peer dependencies in the consumer project as well:
 ```bash
 npm install \
   react@18.3.1 react-dom@18.3.1 \
-  @sito/dashboard@^0.0.80 \
+  @sito/dashboard@^0.0.81 \
   @tanstack/react-query@5.83.0 \
   react-hook-form@7.61.1 \
   @fortawesome/fontawesome-svg-core@7.0.0 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@sito/dashboard-app",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard-app",
-      "version": "0.0.68",
+      "version": "0.0.69",
       "license": "MIT",
       "dependencies": {
-        "@sito/dashboard": "^0.0.80",
+        "@sito/dashboard": "^0.0.81",
         "some-javascript-utils": "^0.10.10"
       },
       "devDependencies": {
@@ -1812,9 +1812,9 @@
       }
     },
     "node_modules/@sito/dashboard": {
-      "version": "0.0.80",
-      "resolved": "https://registry.npmjs.org/@sito/dashboard/-/dashboard-0.0.80.tgz",
-      "integrity": "sha512-eMwC3GkvMO96KfPxUhfsAUACGYDaqNvs3c+JxIHMagpdCK28SUa012w8FBbTR/TVmsji+VjQ4VI4HQdN11a2rA==",
+      "version": "0.0.81",
+      "resolved": "https://registry.npmjs.org/@sito/dashboard/-/dashboard-0.0.81.tgz",
+      "integrity": "sha512-4UUvt6/NQpkFhX1dlq4oTxRusJoQpnIzQFqOlkuhKL3CNJ96dyZ/Or7jbJHp/OGQALak3y0++VCU9gO3/Qvcvg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=18.2 <20",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard-app",
   "private": false,
-  "version": "0.0.68",
+  "version": "0.0.69",
   "type": "module",
   "description": "UI Library with prefab components",
   "main": "dist/dashboard-app.cjs",
@@ -109,7 +109,7 @@
   },
   "dependencies": {
     "some-javascript-utils": "^0.10.10",
-    "@sito/dashboard": "^0.0.80"
+    "@sito/dashboard": "^0.0.81"
   },
   "overrides": {
     "minimatch": "10.2.2"


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Validation

- [ ] `npm run lint`
- [ ] `npm run docs:check`
- [ ] `npm run test`
- [ ] `npm run build`

## Documentation checklist

- [ ] If public behavior changed, I updated `README.md`.
- [ ] If agent rules changed, I updated `AGENTS.md` and kept `CLAUDE.md` aligned.
- [ ] I kept `.sito/*` as upstream/internal reference and did not treat it as canonical `@sito/dashboard-app` integration docs.
- [ ] Provider-order examples remain aligned to `ConfigProvider -> ManagerProvider -> AuthProvider -> NotificationProvider -> DrawerMenuProvider` (`NavbarProvider` when needed).
- [ ] `IconButton` examples are context-aware (`@sito/dashboard` vs `@sito/dashboard-app`).
