### PR TITLE
0.0.70

### DIFF
--- a/.sito/usage-guide.md
+++ b/.sito/usage-guide.md
@@ -453,6 +453,17 @@ import { useRef, useState } from "react";
   onClick={() => console.log("view")}
 />;
 
+{
+  /* Prevent click from bubbling to parent handlers (e.g. row onClick) */
+}
+<Action
+  id="edit"
+  tooltip="Edit"
+  icon={<span>E</span>}
+  onClick={() => console.log("edit")}
+  stopPropagation
+/>;
+
 <Actions
   actions={[
     { id: "edit", tooltip: "Edit", icon: <span>E</span>, onClick: () => {} },
@@ -489,6 +500,7 @@ function ExampleDropdown() {
         open={open}
         onClose={() => setOpen(false)}
         anchorEl={triggerRef.current}
+        closeOnClick
       >
         <ul>
           <li>Item 1</li>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Critical distinction:
 | Icons        | FontAwesome          | 7.0.0   |
 | Forms        | React Hook Form      | 7.61.1  |
 | Server State | TanStack React Query | 5.x     |
-| Base Library | @sito/dashboard      | ^0.0.81 |
+| Base Library | @sito/dashboard      | ^0.0.82 |
 
 ---
 
@@ -50,7 +50,7 @@ All peer dependencies **must** be installed in the consumer project:
 ```bash
 npm install \
   react@18.3.1 react-dom@18.3.1 \
-  @sito/dashboard@^0.0.81 \
+  @sito/dashboard@^0.0.82 \
   @tanstack/react-query@5.83.0 \
   react-hook-form@7.61.1 \
   @fortawesome/fontawesome-svg-core@7.0.0 \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pnpm add @sito/dashboard-app
 - `@tanstack/react-query` `5.83.0`
 - `@supabase/supabase-js` `2.100.0` (optional; only if using Supabase backend)
 - `react-hook-form` `7.61.1`
-- `@sito/dashboard` `^0.0.81`
+- `@sito/dashboard` `^0.0.82`
 - Font Awesome peers defined in `package.json`
 
 Install all peers in consumer apps:
@@ -49,7 +49,7 @@ Install all peers in consumer apps:
 ```bash
 npm install \
   react@18.3.1 react-dom@18.3.1 \
-  @sito/dashboard@^0.0.81 \
+  @sito/dashboard@^0.0.82 \
   @tanstack/react-query@5.83.0 \
   react-hook-form@7.61.1 \
   @fortawesome/fontawesome-svg-core@7.0.0 \

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -13,7 +13,7 @@ Install peer dependencies in the consumer project as well:
 ```bash
 npm install \
   react@18.3.1 react-dom@18.3.1 \
-  @sito/dashboard@^0.0.81 \
+  @sito/dashboard@^0.0.82 \
   @tanstack/react-query@5.83.0 \
   react-hook-form@7.61.1 \
   @fortawesome/fontawesome-svg-core@7.0.0 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@sito/dashboard-app",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard-app",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "license": "MIT",
       "dependencies": {
-        "@sito/dashboard": "^0.0.81",
+        "@sito/dashboard": "^0.0.82",
         "some-javascript-utils": "^0.10.10"
       },
       "devDependencies": {
@@ -1812,9 +1812,9 @@
       }
     },
     "node_modules/@sito/dashboard": {
-      "version": "0.0.81",
-      "resolved": "https://registry.npmjs.org/@sito/dashboard/-/dashboard-0.0.81.tgz",
-      "integrity": "sha512-4UUvt6/NQpkFhX1dlq4oTxRusJoQpnIzQFqOlkuhKL3CNJ96dyZ/Or7jbJHp/OGQALak3y0++VCU9gO3/Qvcvg==",
+      "version": "0.0.82",
+      "resolved": "https://registry.npmjs.org/@sito/dashboard/-/dashboard-0.0.82.tgz",
+      "integrity": "sha512-V0cC4/cjJ3s2vu13Z4Mt2IXLc+Le1QO5YgUPwadICeaKuFSmE42gbDcYfXppmkeC2POzvYdu5hmhs/tzuJNuTQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=18.2 <20",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard-app",
   "private": false,
-  "version": "0.0.69",
+  "version": "0.0.70",
   "type": "module",
   "description": "UI Library with prefab components",
   "main": "dist/dashboard-app.cjs",
@@ -109,7 +109,7 @@
   },
   "dependencies": {
     "some-javascript-utils": "^0.10.10",
-    "@sito/dashboard": "^0.0.81"
+    "@sito/dashboard": "^0.0.82"
   },
   "overrides": {
     "minimatch": "10.2.2"


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Validation

- [ ] `npm run lint`
- [ ] `npm run docs:check`
- [ ] `npm run test`
- [ ] `npm run build`

## Documentation checklist

- [ ] If public behavior changed, I updated `README.md`.
- [ ] If agent rules changed, I updated `AGENTS.md` and kept `CLAUDE.md` aligned.
- [ ] I kept `.sito/*` as upstream/internal reference and did not treat it as canonical `@sito/dashboard-app` integration docs.
- [ ] Provider-order examples remain aligned to `ConfigProvider -> ManagerProvider -> AuthProvider -> NotificationProvider -> DrawerMenuProvider` (`NavbarProvider` when needed).
- [ ] `IconButton` examples are context-aware (`@sito/dashboard` vs `@sito/dashboard-app`).
