### PR TITLE
0.0.71

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -679,6 +679,9 @@ useEffect(() => {
   - `"ALL"` => include both active and deleted rows
 - `import` with `override: false` uses `store.add` (throws on duplicate key); `override: true` uses `store.put` (upsert).
 - Keep consumer-facing behavior aligned with your `BaseClient` implementation; do not couple UI code to raw IndexedDB details.
+- Multiple clients may share the same `dbName` (one store per client). Each instance registers its `table` in an internal registry, so opening one client will not drop stores registered by other clients.
+- Concurrent `open()` calls are serialized per `dbName` through an internal lock; parallel CRUD across sibling clients is safe.
+- The effective open version is `max(registered versions, current db version)`; when a registered store is missing, the version is bumped once and all registered stores are created in a single `onupgradeneeded` pass.
 
 ---
 
@@ -847,7 +850,7 @@ Consumer projects must provide translations for these namespaces.
 10. **Respect the styling system** — use `State` enum and `*StateClassName` utilities for stateful inputs; do not override with inline styles.
 11. **Do not add `any` types** — the library is fully typed; if types seem missing, check for the correct DTO or utility type.
 12. **`IconButton` is overridden** — the export from this library wraps FontAwesome and expects `icon: IconDefinition`, not a React node.
-13. **Use `IndexedDBClient` as offline fallback** — when building offline-capable features, extend `IndexedDBClient` instead of writing custom storage logic. Keep its consumer-facing behavior aligned with your `BaseClient` implementation, and never instantiate it in SSR/Node contexts.
+13. **Use `IndexedDBClient` as offline fallback** — when building offline-capable features, extend `IndexedDBClient` instead of writing custom storage logic. Keep its consumer-facing behavior aligned with your `BaseClient` implementation, and never instantiate it in SSR/Node contexts. When multiple entity clients belong to the same logical database, reuse the same `dbName` across them; the internal registry + open-lock handle shared-schema creation and concurrent opens.
 14. **Sign-in should send `rememberMe` when the UI exposes a remember option.**
 15. **Do not implement ad-hoc token refresh in consumer apps** — rely on the centralized refresh/retry behavior in `APIClient`/`BaseClient`.
 16. **Keep auth storage key config aligned** — if custom keys are used in `AuthProvider`, configure the same keys in manager/client auth config (`rememberKey`, `refreshTokenKey`, `accessTokenExpiresAtKey`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.71] - 2026-04-19
+
+### Fixed
+
+- `IndexedDBClient` now supports multiple clients (different stores) sharing the same `dbName` without clobbering each other's object stores. Previously, opening a second client with a new `table` under an existing database could leave earlier stores missing or trigger `NotFoundError` on CRUD calls.
+- `IndexedDBClient.open` is now serialized per `dbName` via an internal lock, preventing races between concurrent `open()` calls that could fire overlapping `onupgradeneeded` events.
+- `IndexedDBClient` now probes the existing database version/stores before opening, bumps the version only when required stores are missing, and recreates all registered stores in a single `onupgradeneeded` pass.
+- `IndexedDBClient` now rejects explicitly on `onblocked` events during probe/upgrade instead of hanging.
+
+### Added
+
+- Internal store registry and open-lock utilities in `IndexedDBClient` so every client instance contributes its `table` to the shared schema for its `dbName`.
+- New `IndexedDBClient` test suite "Shared database across multiple stores" covering concurrent multi-store inserts and late-registered stores with prior data preserved.
+
 ## [0.0.67] - 2026-04-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -841,6 +841,34 @@ Contract and filtering notes:
   - `softDeleteScope: "DELETED"` => deleted rows (`deletedAt` not null/undefined)
   - `softDeleteScope: "ALL"` => all rows
 
+### Sharing a database across multiple entity clients
+
+Multiple `IndexedDBClient` instances can share the same `dbName` to co-locate related stores (e.g. `users`, `accounts`, `transactions`) in a single database. Each client registers its `table` internally, so opening one store no longer drops stores registered by other clients.
+
+```ts
+class UsersIndexedDBClient extends IndexedDBClient<"users" /* ... */> {
+  constructor() {
+    super("users", "my-app-db");
+  }
+}
+
+class AccountsIndexedDBClient extends IndexedDBClient<"accounts" /* ... */> {
+  constructor() {
+    super("accounts", "my-app-db");
+  }
+}
+
+// Concurrent opens are serialized per `dbName` and share one upgrade pass.
+const users = new UsersIndexedDBClient();
+const accounts = new AccountsIndexedDBClient();
+```
+
+Notes:
+
+- Pass the same `dbName` to every client that belongs to the same logical database.
+- `version` is the minimum schema version for that client; the actual open runs at `max(registered versions, current db version)` and bumps automatically when a registered store is missing.
+- Opens are serialized per `dbName` via an internal lock, so parallel `Promise.all([...])` calls across clients are safe.
+
 ## Tests
 
 Automated tests are configured with `Vitest` + `@testing-library/react`.

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -680,6 +680,25 @@ class ProductsIndexedDBClient extends IndexedDBClient<
 }
 ```
 
+Multiple entity clients may share a single `dbName` to co-locate related stores (for example `users`, `accounts`, `transactions`) in one IndexedDB database. Each instance registers its `table` internally, so:
+
+- Opening a new client no longer drops stores registered by other clients for the same `dbName`.
+- Concurrent `open()` calls are serialized per `dbName` through an internal lock.
+- When a registered store is missing, the schema version is bumped once and every registered store is (re)created in a single `onupgradeneeded` pass.
+
+```ts
+// All three live under "my-app-db" and can be used concurrently.
+const users = new UsersIndexedDBClient();
+const accounts = new AccountsIndexedDBClient();
+const transactions = new TransactionsIndexedDBClient();
+
+await Promise.all([
+  users.insert({ name: "Alice", email: "alice@test.com" }),
+  accounts.insert({ userId: 1, balance: 100 }),
+  transactions.insert({ accountId: 1, amount: 10, description: "Coffee" }),
+]);
+```
+
 ### 7.3 Supabase client with `SupabaseDataClient`
 
 ```ts

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -994,6 +994,53 @@ export const productsClient = navigator.onLine
   : new ProductsIndexedDBClient();
 ```
 
+### 14.1 Sharing a `dbName` across multiple `IndexedDBClient` instances
+
+When several entity clients belong to the same logical database, construct them with the same `dbName`. The client's internal registry tracks every `table`, and opens are serialized per `dbName` so concurrent CRUD is safe and no previously registered store is dropped by later opens.
+
+```ts
+class UsersIndexedDBClient extends IndexedDBClient<
+  "users",
+  UserDto,
+  UserCommonDto,
+  UserCreateDto,
+  UserUpdateDto,
+  UserFilterDto,
+  UserImportPreviewDto
+> {
+  constructor() {
+    super("users", "my-app-db");
+  }
+}
+
+class AccountsIndexedDBClient extends IndexedDBClient<
+  "accounts",
+  AccountDto,
+  AccountCommonDto,
+  AccountCreateDto,
+  AccountUpdateDto,
+  AccountFilterDto,
+  AccountImportPreviewDto
+> {
+  constructor() {
+    super("accounts", "my-app-db");
+  }
+}
+
+const users = new UsersIndexedDBClient();
+const accounts = new AccountsIndexedDBClient();
+
+await Promise.all([
+  users.insert({ name: "Alice", email: "alice@test.com" }),
+  accounts.insert({ userId: 1, balance: 100 }),
+]);
+```
+
+Notes:
+
+- The effective open version is `max(registered versions, current db version)`; if a registered store is missing at open time, the version is bumped once and all registered stores are created in a single `onupgradeneeded` pass.
+- Registering a new store after the database already exists is supported — the next `open()` detects the missing store and upgrades transparently.
+
 ## 15. Ready-to-use export action with `useExportActionMutate`
 
 ```tsx

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -159,6 +159,20 @@ const authStorageKeys = {
 
 - Instantiate only in browser (for example inside `useEffect` or after checking `typeof window !== "undefined"`).
 
+### 2.11.1 `IndexedDBClient`: `NotFoundError` / missing object store when sharing a `dbName`
+
+**Cause**
+
+- In older versions, opening a second client against an existing database could overwrite or skip stores registered by other clients.
+
+**Fix**
+
+- Keep `dbName` identical across every client that belongs to the same logical database and let each client construct normally. The internal store registry + open-lock now:
+  - Track every registered `table` per `dbName`.
+  - Serialize concurrent `open()` calls per `dbName`.
+  - Bump the schema version and (re)create all registered stores in one `onupgradeneeded` pass when a store is missing.
+- Do not manually call `indexedDB.open(...)` from consumer code; rely on the client so the registry stays consistent.
+
 ### 2.12 App crashes in SSR/server-render pipelines
 
 **Cause**

--- a/src/lib/api/IndexedDBClient.test.ts
+++ b/src/lib/api/IndexedDBClient.test.ts
@@ -582,3 +582,86 @@ describe("Full hierarchy: User → Accounts → Transactions", () => {
     expect(restoredAcc.deletedAt).toBeNull();
   });
 });
+
+// ─── Shared DB across multiple stores ────────────────────────────────────────
+
+describe("Shared database across multiple stores", () => {
+  it("creates every registered store even when clients open concurrently", async () => {
+    const dbName = freshDb();
+    const version = 2;
+
+    const users = new IndexedDBClient<
+      "users",
+      UserDto,
+      UserCommonDto,
+      UserAddDto,
+      UserUpdateDto,
+      UserFilterDto,
+      UserImportPreviewDto
+    >("users", dbName, version);
+
+    const accounts = new IndexedDBClient<
+      "accounts",
+      AccountDto,
+      AccountCommonDto,
+      AccountAddDto,
+      AccountUpdateDto,
+      AccountFilterDto,
+      AccountImportPreviewDto
+    >("accounts", dbName, version);
+
+    const transactions = new IndexedDBClient<
+      "transactions",
+      TransactionDto,
+      TransactionCommonDto,
+      TransactionAddDto,
+      TransactionUpdateDto,
+      TransactionFilterDto,
+      TransactionImportPreviewDto
+    >("transactions", dbName, version);
+
+    const [u, a, t] = await Promise.all([
+      users.insert({ name: "Alice", email: "alice@test.com" }),
+      accounts.insert({ userId: 1, balance: 100 }),
+      transactions.insert({ accountId: 1, amount: 10, description: "Coffee" }),
+    ]);
+
+    expect(u.id).toBeGreaterThan(0);
+    expect(a.id).toBeGreaterThan(0);
+    expect(t.id).toBeGreaterThan(0);
+  });
+
+  it("adds a missing store when a new client registers after initial open", async () => {
+    const dbName = freshDb();
+    const version = 1;
+
+    const users = new IndexedDBClient<
+      "users",
+      UserDto,
+      UserCommonDto,
+      UserAddDto,
+      UserUpdateDto,
+      UserFilterDto,
+      UserImportPreviewDto
+    >("users", dbName, version);
+
+    await users.insert({ name: "Alice", email: "alice@test.com" });
+    users.close();
+
+    const accounts = new IndexedDBClient<
+      "accounts",
+      AccountDto,
+      AccountCommonDto,
+      AccountAddDto,
+      AccountUpdateDto,
+      AccountFilterDto,
+      AccountImportPreviewDto
+    >("accounts", dbName, version);
+
+    const created = await accounts.insert({ userId: 1, balance: 50 });
+    expect(created.id).toBeGreaterThan(0);
+
+    const existing = await users.getById(1);
+    expect(existing.name).toBe("Alice");
+  });
+});

--- a/src/lib/api/IndexedDBClient.ts
+++ b/src/lib/api/IndexedDBClient.ts
@@ -121,7 +121,8 @@ export class IndexedDBClient<
   }
 
   private async openLocked(): Promise<IDBDatabase> {
-    if (this.db && this.db.objectStoreNames.contains(this.table)) return this.db;
+    if (this.db && this.db.objectStoreNames.contains(this.table))
+      return this.db;
     if (this.db) this.close();
 
     const registered = getRegisteredStores(this.dbName);
@@ -169,9 +170,7 @@ export class IndexedDBClient<
       };
 
       request.onblocked = () => {
-        reject(
-          new Error(`IndexedDB upgrade blocked for ${this.dbName}`),
-        );
+        reject(new Error(`IndexedDB upgrade blocked for ${this.dbName}`));
       };
     });
   }

--- a/src/lib/api/IndexedDBClient.ts
+++ b/src/lib/api/IndexedDBClient.ts
@@ -12,6 +12,71 @@ import {
   SoftDeleteScope,
 } from "lib";
 
+type StoreRegistryEntry = {
+  stores: Set<string>;
+  version: number;
+};
+
+const storeRegistry: Map<string, StoreRegistryEntry> = new Map();
+const openLocks: Map<string, Promise<unknown>> = new Map();
+
+const registerStore = (
+  dbName: string,
+  store: string,
+  version: number,
+): void => {
+  const entry = storeRegistry.get(dbName);
+  if (entry) {
+    entry.stores.add(store);
+    if (version > entry.version) entry.version = version;
+    return;
+  }
+  storeRegistry.set(dbName, {
+    stores: new Set([store]),
+    version,
+  });
+};
+
+const getRegisteredStores = (dbName: string): Set<string> =>
+  storeRegistry.get(dbName)?.stores ?? new Set();
+
+const getRegisteredVersion = (dbName: string): number =>
+  storeRegistry.get(dbName)?.version ?? 1;
+
+/** Run `task` serialized per `dbName` so concurrent opens don't race upgrades. */
+const withOpenLock = async <T>(
+  dbName: string,
+  task: () => Promise<T>,
+): Promise<T> => {
+  const previous = openLocks.get(dbName) ?? Promise.resolve();
+  const next = previous.then(task, task);
+  openLocks.set(
+    dbName,
+    next.catch(() => undefined),
+  );
+  return next;
+};
+
+const probeDatabase = (
+  dbName: string,
+): Promise<{ version: number; stores: Set<string> }> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(dbName);
+    request.onsuccess = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      const version = db.version;
+      const stores = new Set<string>(Array.from(db.objectStoreNames));
+      db.close();
+      resolve({ version, stores });
+    };
+    request.onerror = (event) => {
+      reject((event.target as IDBOpenDBRequest).error);
+    };
+    request.onblocked = () => {
+      reject(new Error(`IndexedDB probe blocked for ${dbName}`));
+    };
+  });
+
 /** Generic IndexedDB-backed client mirroring BaseClient CRUD semantics. */
 export class IndexedDBClient<
   Tables extends string,
@@ -36,6 +101,7 @@ export class IndexedDBClient<
     this.table = table;
     this.dbName = dbName;
     this.version = version;
+    registerStore(dbName, table, version);
   }
 
   close() {
@@ -46,18 +112,47 @@ export class IndexedDBClient<
   }
 
   private open(): Promise<IDBDatabase> {
-    if (this.db) return Promise.resolve(this.db);
+    if (this.db && this.db.objectStoreNames.contains(this.table)) {
+      return Promise.resolve(this.db);
+    }
+    if (this.db) this.close();
+
+    return withOpenLock(this.dbName, () => this.openLocked());
+  }
+
+  private async openLocked(): Promise<IDBDatabase> {
+    if (this.db && this.db.objectStoreNames.contains(this.table)) return this.db;
+    if (this.db) this.close();
+
+    const registered = getRegisteredStores(this.dbName);
+    const { version: currentVersion, stores: currentStores } =
+      await probeDatabase(this.dbName);
+
+    let missing = false;
+    for (const store of registered) {
+      if (!currentStores.has(store)) {
+        missing = true;
+        break;
+      }
+    }
+
+    const desired = Math.max(this.version, getRegisteredVersion(this.dbName));
+    const targetVersion = missing
+      ? Math.max(currentVersion + 1, desired)
+      : Math.max(currentVersion, desired);
 
     return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this.dbName, this.version);
+      const request = indexedDB.open(this.dbName, targetVersion);
 
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result;
-        if (!db.objectStoreNames.contains(this.table)) {
-          db.createObjectStore(this.table, {
-            keyPath: "id",
-            autoIncrement: true,
-          });
+        for (const store of registered) {
+          if (!db.objectStoreNames.contains(store)) {
+            db.createObjectStore(store, {
+              keyPath: "id",
+              autoIncrement: true,
+            });
+          }
         }
       };
 
@@ -71,6 +166,12 @@ export class IndexedDBClient<
 
       request.onerror = (event) => {
         reject((event.target as IDBOpenDBRequest).error);
+      };
+
+      request.onblocked = () => {
+        reject(
+          new Error(`IndexedDB upgrade blocked for ${this.dbName}`),
+        );
       };
     });
   }


### PR DESCRIPTION
## [0.0.71] - 2026-04-19

### Fixed

- `IndexedDBClient` now supports multiple clients (different stores) sharing the same `dbName` without clobbering each other's object stores. Previously, opening a second client with a new `table` under an existing database could leave earlier stores missing or trigger `NotFoundError` on CRUD calls.
- `IndexedDBClient.open` is now serialized per `dbName` via an internal lock, preventing races between concurrent `open()` calls that could fire overlapping `onupgradeneeded` events.
- `IndexedDBClient` now probes the existing database version/stores before opening, bumps the version only when required stores are missing, and recreates all registered stores in a single `onupgradeneeded` pass.
- `IndexedDBClient` now rejects explicitly on `onblocked` events during probe/upgrade instead of hanging.

### Added

- Internal store registry and open-lock utilities in `IndexedDBClient` so every client instance contributes its `table` to the shared schema for its `dbName`.
- New `IndexedDBClient` test suite "Shared database across multiple stores" covering concurrent multi-store inserts and late-registered stores with prior data preserved.