### PR TITLE
0.0.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.72] - 2026-04-26
+
+### Fixed
+
+- `ImportDialog` now renders the parse error block only when `parseError` exists, avoiding an unnecessary empty error placeholder in the normal flow.
+- Updated `ImportDialog` error message styling utility from `text-error` to `text-bg-error` to align with the current token/class usage.
+
 ## [0.0.71] - 2026-04-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard-app",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard-app",
-      "version": "0.0.70",
+      "version": "0.0.71",
       "license": "MIT",
       "dependencies": {
         "@sito/dashboard": "^0.0.82",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard-app",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard-app",
-      "version": "0.0.71",
+      "version": "0.0.72",
       "license": "MIT",
       "dependencies": {
         "@sito/dashboard": "^0.0.82",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard-app",
   "private": false,
-  "version": "0.0.70",
+  "version": "0.0.71",
   "type": "module",
   "description": "UI Library with prefab components",
   "main": "dist/dashboard-app.cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard-app",
   "private": false,
-  "version": "0.0.71",
+  "version": "0.0.72",
   "type": "module",
   "description": "UI Library with prefab components",
   "main": "dist/dashboard-app.cjs",

--- a/src/components/Dialog/ImportDialog/ImportDialog.tsx
+++ b/src/components/Dialog/ImportDialog/ImportDialog.tsx
@@ -166,7 +166,7 @@ export const ImportDialog = <EntityDto extends ImportPreviewDto>(
           })}
         </span>
       </label>
-      <ErrorComponent message={parseError} />
+      {parseError && <ErrorComponent message={parseError} />}
       {processing && <Loading />}
       {renderCustomPreview
         ? renderCustomPreview(previewItems)

--- a/src/components/Dialog/ImportDialog/styles.css
+++ b/src/components/Dialog/ImportDialog/styles.css
@@ -21,7 +21,7 @@
 }
 
 .import-error-message {
-  @apply text-error text-sm mt-2;
+  @apply text-bg-error text-sm mt-2;
 }
 
 .import-loading {


### PR DESCRIPTION

## [0.0.72] - 2026-04-26

### Fixed

- `ImportDialog` now renders the parse error block only when `parseError` exists, avoiding an unnecessary empty error placeholder in the normal flow.
- Updated `ImportDialog` error message styling utility from `text-error` to `text-bg-error` to align with the current token/class usage.