### PR TITLE
0.0.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.88] - 2026-06-21
+## [0.0.89] - 2026-06-21
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.88] - 2026-06-21
+
+### Changed
+
+- Updated the global `Page` refresh action icon from `faRotateLeft` to `faArrowsRotate`, giving refresh controls the standard rotating-arrows visual.
+- Aligned the lockfile with the declared `@sito/dashboard` `^0.0.87` dependency.
+
 ## [0.0.87] - 2026-06-15
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard-app",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard-app",
-      "version": "0.0.88",
+      "version": "0.0.89",
       "license": "MIT",
       "dependencies": {
         "@sito/dashboard": "^0.0.87",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.88",
       "license": "MIT",
       "dependencies": {
-        "@sito/dashboard": "^0.0.86",
+        "@sito/dashboard": "^0.0.87",
         "@use-gesture/react": "^10.3.1",
         "some-javascript-utils": "^0.10.10"
       },
@@ -1949,9 +1949,9 @@
       }
     },
     "node_modules/@sito/dashboard": {
-      "version": "0.0.86",
-      "resolved": "https://registry.npmjs.org/@sito/dashboard/-/dashboard-0.0.86.tgz",
-      "integrity": "sha512-9Rg8WJLGpUTP6bQT6MIDy50RXahh9BzwpstQfo9k8S0lIQCHv/tBAkZB1O3/IOu/BnVUXHoqUTi5GSsPw4Ea4w==",
+      "version": "0.0.87",
+      "resolved": "https://registry.npmjs.org/@sito/dashboard/-/dashboard-0.0.87.tgz",
+      "integrity": "sha512-GCIE+YQY/45cP+0QhghmytCzJo08dJAja3q/a+SYqxiRfUoOHwvd7YESSBUOlDDyGPRBbZC2IGIrEUrBj7zYww==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=18.2 <20",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard-app",
   "private": false,
-  "version": "0.0.87",
+  "version": "0.0.88",
   "type": "module",
   "description": "UI Library with prefab components",
   "main": "dist/dashboard-app.cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard-app",
   "private": false,
-  "version": "0.0.88",
+  "version": "0.0.89",
   "type": "module",
   "description": "UI Library with prefab components",
   "main": "dist/dashboard-app.cjs",

--- a/src/components/app/Page/Page.tsx
+++ b/src/components/app/Page/Page.tsx
@@ -21,8 +21,8 @@ import { PagePropsType } from "./types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faAdd,
+  faArrowsRotate,
   faFilter,
-  faRotateLeft,
 } from "@fortawesome/free-solid-svg-icons";
 
 // lib
@@ -74,7 +74,7 @@ export const Page = <TEntity extends BaseEntityDto>(
       const refreshAction: ActionType<TEntity> = {
         id: GlobalActions.Refresh,
         onClick: () => queryClient.invalidateQueries({ queryKey }),
-        icon: <FontAwesomeIcon icon={faRotateLeft} />,
+        icon: <FontAwesomeIcon icon={faArrowsRotate} />,
         tooltip: t("_pages:common.actions.refresh.text"),
       };
       pActions.unshift(refreshAction);


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

## [0.0.88] - 2026-06-21

### Changed

- Updated the global `Page` refresh action icon from `faRotateLeft` to `faArrowsRotate`, giving refresh controls the standard rotating-arrows visual.
- Aligned the lockfile with the declared `@sito/dashboard` `^0.0.87` dependency.