### PR TITLE
v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-07-16
+
+### Added
+
+- Added `IconButton.iconSize` for selecting a FontAwesome predefined size,
+  defaulting to `"sm"` for a smaller icon footprint without changing the
+  button's clickable area.
+
 ## [0.1.0] - 2026-07-16
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard-app",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "UI Library with prefab components",
   "main": "dist/dashboard-app.cjs",

--- a/src/components/ui/Buttons/IconButton.tsx
+++ b/src/components/ui/Buttons/IconButton.tsx
@@ -12,6 +12,15 @@ export type { IconButtonPropsLocalType } from "./types";
  * @param props - Icon button props with a FontAwesome icon.
  * @returns Wrapped dashboard IconButton element.
  */
-export const AppIconButton = ({ icon, ...rest }: IconButtonPropsLocalType) => {
-  return <IconButtonBase icon={<FontAwesomeIcon icon={icon} />} {...rest} />;
+export const AppIconButton = ({
+  icon,
+  iconSize = "sm",
+  ...rest
+}: IconButtonPropsLocalType) => {
+  return (
+    <IconButtonBase
+      icon={<FontAwesomeIcon icon={icon} size={iconSize} />}
+      {...rest}
+    />
+  );
 };

--- a/src/components/ui/Buttons/types.ts
+++ b/src/components/ui/Buttons/types.ts
@@ -1,8 +1,10 @@
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import type { FontAwesomeIconProps } from "@fortawesome/react-fontawesome";
 import type { IconButtonPropsType } from "@sito/dashboard";
 
 export type IconButtonPropsLocalType = Omit<IconButtonPropsType, "icon"> & {
   icon: IconDefinition;
+  iconSize?: FontAwesomeIconProps["size"];
 };
 
 export type ToTopPropsType = Omit<


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

## [0.1.1] - 2026-07-16

### Added

- Added `IconButton.iconSize` for selecting a FontAwesome predefined size,
  defaulting to `"sm"` for a smaller icon footprint without changing the
  button's clickable area.